### PR TITLE
Check fix version changes once the sprint is up.

### DIFF
--- a/src/main/java/org/jboss/jbossset/bugclerk/utils/WhiteListSingleton.java
+++ b/src/main/java/org/jboss/jbossset/bugclerk/utils/WhiteListSingleton.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.jbossset.bugclerk.utils;
+
+import org.jboss.set.aphrodite.domain.User;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by Marek Marusic <mmarusic@redhat.com> on 6/9/17.
+ */
+/* This is thread safe lazy loaded singleton,
+which contains white list of users who can modify jira issues fix versions.*/
+public class WhiteListSingleton {
+    private Map<String, List<User>> sprintWhiteList;
+
+    private WhiteListSingleton() {
+        sprintWhiteList = new HashMap<>();
+        parseSprintWhiteListInput();
+    }
+
+    private void parseSprintWhiteListInput() {
+        List<User> allowedUsers = new ArrayList<>();
+        allowedUsers.add(User.createWithUsername("GSS"));
+        allowedUsers.add(User.createWithUsername("ReleaseCoordinator"));
+        sprintWhiteList.put("EAP 7.0.3", allowedUsers);
+    }
+
+    private static class SingletonHelper {
+        private static final WhiteListSingleton INSTANCE = new WhiteListSingleton();
+    }
+
+    public static WhiteListSingleton getInstance() {
+        return SingletonHelper.INSTANCE;
+    }
+
+    public boolean isInSprintWhiteList(User user, String sprint) {
+        if (! sprintWhiteList.containsKey(sprint) )
+            return false;
+        List<User> allowedUsers = sprintWhiteList.get(sprint);
+        return allowedUsers.stream().anyMatch(allowedUser -> allowedUser.equals(user));
+    }
+
+}

--- a/src/main/resources/org/jboss/jbossset/bugclerk/FixVersionChangesDuringSprint.drl
+++ b/src/main/resources/org/jboss/jbossset/bugclerk/FixVersionChangesDuringSprint.drl
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.jbossset.bugclerk;
+
+import org.jboss.set.aphrodite.domain.User;
+import org.jboss.set.aphrodite.domain.Issue;
+import org.jboss.set.aphrodite.domain.IssuePriority;
+import org.jboss.set.aphrodite.domain.Comment;
+import org.jboss.set.aphrodite.domain.IssueStatus;
+import org.jboss.set.aphrodite.domain.FlagStatus;
+import org.jboss.set.aphrodite.issue.trackers.jira.JiraIssue;
+import org.jboss.set.aphrodite.issue.trackers.jira.JiraChangelogGroup;
+
+import java.util.Date;
+
+import org.jboss.jbossset.bugclerk.Violation;
+import org.jboss.jbossset.bugclerk.Severity;
+import org.jboss.jbossset.bugclerk.utils.RulesHelper;
+
+global java.util.List list
+
+rule "FixVersionChangesDuringSprint"
+  salience 0
+  dialect "mvel"
+  when
+      $candidate : Candidate($jiraIssue: bug#JiraIssue,  filtered == false);
+      $group : JiraChangelogGroup() from RulesHelper.getLastFixVersionChangeDuringSprint($jiraIssue);
+      $sprint : String() from $jiraIssue.getSprintRelease();
+      $author : User() from $group.getAuthor();
+      eval(RulesHelper.isFixVersionChangeDoneByAllowedUser($author, $sprint) == false);
+  then
+    $candidate.addViolationOnce( new Violation("FixVersionChangesDuringSprint", "test violation", Severity.MINOR) );
+end

--- a/src/test/java/org/jboss/jbossset/bugclerk/checks/FixVersionChangesDuringSprint.java
+++ b/src/test/java/org/jboss/jbossset/bugclerk/checks/FixVersionChangesDuringSprint.java
@@ -1,0 +1,133 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.jbossset.bugclerk.checks;
+
+import org.jboss.jbossset.bugclerk.AbstractCheckRunner;
+import org.jboss.jbossset.bugclerk.Candidate;
+import org.jboss.jbossset.bugclerk.MockUtils;
+import org.jboss.jbossset.bugclerk.checks.utils.CollectionUtils;
+import org.jboss.jbossset.bugclerk.utils.RulesHelper;
+import org.jboss.set.aphrodite.domain.User;
+import org.jboss.set.aphrodite.issue.trackers.jira.JiraChangelogGroup;
+import org.jboss.set.aphrodite.issue.trackers.jira.JiraChangelogItem;
+import org.jboss.set.aphrodite.issue.trackers.jira.JiraIssue;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.List;
+
+import static org.jboss.jbossset.bugclerk.checks.utils.AssertsHelper.assertResultsIsAsExpected;
+import static org.junit.Assert.assertEquals;
+
+public class FixVersionChangesDuringSprint extends AbstractCheckRunner {
+    private String bugId;
+    private List<JiraChangelogGroup> changelog;
+    private User authorOfChange;
+    private JiraChangelogGroup lastFixVersionChange;
+
+    @Before
+    public void resetMockData() {
+        bugId = "143794";
+        authorOfChange = User.createWithUsername("ReleaseCoordinator");
+        resetChangelog();
+    }
+
+    private void resetChangelog() {
+        changelog = new ArrayList<>();
+    }
+
+
+    @Test
+    public void testAllowedUserChangedFixVersion() {
+        createChangelogWithVersionChangeAndSprint();
+        addGroupWithFixVerChangeDuringSprint(new GregorianCalendar(2001, 1, 1).getTime());
+        testFixVersionChangeDoneByAllowedUser(true);
+    }
+
+    private void createChangelogWithVersionChangeAndSprint() {
+        resetChangelog();
+        addGroupWithItem(new JiraChangelogItem("Fix Version", "null", "null", "12331152", "7.0.3.CR1"),
+                new GregorianCalendar(1999, 1, 1).getTime());
+        addGroupWithItem(new JiraChangelogItem("Sprint", "null", "null", "5086", "EAP 7.0.3"),
+                new GregorianCalendar(2000, 1, 1).getTime());
+    }
+
+    private void addGroupWithItem(JiraChangelogItem item, Date created) {
+        changelog.add(createGroupWithItem(item, created));
+    }
+
+    private void addGroupWithFixVerChangeDuringSprint(Date created) {
+        lastFixVersionChange = createGroupWithItem(new JiraChangelogItem("Fix Version", "null", "null", "12331152", "7.0.3.CR2"),
+                created);
+        changelog.add(lastFixVersionChange);
+    }
+
+    private JiraChangelogGroup createGroupWithItem(JiraChangelogItem item, Date created) {
+        List<JiraChangelogItem> items = new ArrayList<>();
+        items.add(item);
+        return new JiraChangelogGroup(authorOfChange, created, items);
+    }
+
+    private void testFixVersionChangeDoneByAllowedUser(boolean doneByAllowedUser) {
+        JiraIssue jiraIssueMock = mockIssue();
+
+        JiraChangelogGroup fixVersionChangeGroup = RulesHelper.getLastFixVersionChangeDuringSprint(jiraIssueMock);
+        assertEquals(fixVersionChangeGroup, lastFixVersionChange);
+
+        int numberViolationExpected = doneByAllowedUser ? 0 : 1;
+        assertResultsIsAsExpected(engine.runCheckOnBugs(CollectionUtils.asSetOf(new Candidate(jiraIssueMock)), checkName), checkName, bugId, numberViolationExpected);
+    }
+
+    private JiraIssue mockIssue() {
+        JiraIssue jiraIssueMock = MockUtils.mockJiraIssue(bugId, "A Summary...");
+        Mockito.when(jiraIssueMock.getSprintRelease()).thenReturn("EAP 7.0.3");
+        Mockito.when(jiraIssueMock.getChangelog()).thenReturn(changelog);
+        return jiraIssueMock;
+    }
+
+    @Test
+    public void testNOTAllowedUserChangedFixVersion() {
+        createChangelogWithVersionChangeAndSprint();
+        addGroupWithFixVerChangeDuringSprint(new GregorianCalendar(2001, 1, 1).getTime());
+
+        authorOfChange = User.createWithUsername("NotAllowedUser");
+        addGroupWithFixVerChangeDuringSprint(new GregorianCalendar(2002, 1, 1).getTime());
+
+        testFixVersionChangeDoneByAllowedUser(false);
+    }
+
+    @Test
+    public void testAllowedUserChangedFixVersionAfterNotAllowedUserChangedIt() {
+        createChangelogWithVersionChangeAndSprint();
+        authorOfChange = User.createWithUsername("NotAllowedUser");
+        addGroupWithFixVerChangeDuringSprint(new GregorianCalendar(2001, 1, 1).getTime());
+
+        authorOfChange = User.createWithUsername("ReleaseCoordinator");
+        addGroupWithFixVerChangeDuringSprint(new GregorianCalendar(2002, 1, 1).getTime());
+
+        testFixVersionChangeDoneByAllowedUser(true);
+    }
+}


### PR DESCRIPTION
Hi,

1. Since there is not any source which would contain needed white list of users allowed to edit the fix version right now I have created a singleton class with some fake users and fake sprints for now.

2. Apparently there is only BasicUser object in the chagnelog which aphrodite gets from jira api.
BasicUser contains only user name and display name, therefore the check is only done against the user name for now.

3. There isn't any way how to check if the sprint is active or not through aphrodite, so the check is only run on changes made after last set sprint.

4. I am not sure whether I should check all the fix version changes after the sprint was set, because the user could be already warned and he already might have fixed the mistake. In this case there would be a violation reported on the issue even though the user fixed the mistake.
Therefore it checks only if the last fix version change was done by user from whitelist.

What do you think about this behaviour, should I change anything?

Github issue: https://github.com/jboss-set/bug-clerk/issues/44
bugclerk issue: #45