### PR TITLE
Fixes for check upgrade JIRAs for Sprint/Stream version discrepencies.

### DIFF
--- a/src/main/java/org/jboss/jbossset/bugclerk/utils/FixVersionHelper.java
+++ b/src/main/java/org/jboss/jbossset/bugclerk/utils/FixVersionHelper.java
@@ -28,8 +28,9 @@ import org.jboss.set.aphrodite.domain.IssueType;
 import org.jboss.set.aphrodite.domain.Release;
 import org.jboss.set.aphrodite.issue.trackers.jira.JiraIssue;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Created by Marek Marusic <mmarusic@redhat.com> on 7/11/17.
@@ -53,26 +54,22 @@ public class FixVersionHelper {
     }
 
     static List<Issue> filterIssuesWithDifferentFixVersionOrSprint(JiraIssue issue, List<Issue> incorporatedIssues) {
-
-        List<Issue> issuesWithWrongFixVersion = new ArrayList<>();
-        incorporatedIssues.stream()
+        return incorporatedIssues.stream()
                 .filter(i -> !haveIssuesEqualSpringAndFixVersion(issue, (JiraIssue) i))
-                .forEach(issuesWithWrongFixVersion::add);
-
-        return issuesWithWrongFixVersion;
+                .collect(Collectors.toList());
     }
 
     private static boolean haveIssuesEqualSpringAndFixVersion(JiraIssue issue, JiraIssue i) {
-        Release upgradeIssueGARelease = findFirstGARelease(issue.getReleases());
+        Optional<Release> upgradeIssueGARelease = findFirstGARelease(issue.getReleases());
 
         return upgradeIssueGARelease.equals(findFirstGARelease(i.getReleases()))
                 && issue.getSprintRelease().equals(i.getSprintRelease());
     }
 
-    private static Release findFirstGARelease(List<Release> releases) {
+    private static Optional<Release> findFirstGARelease(List<Release> releases) {
         if (releases == null)
             return null;
-        return releases.stream().filter(FixVersionHelper::isReleaseGA).findFirst().orElse(null);
+        return releases.stream().filter(FixVersionHelper::isReleaseGA).findFirst();
     }
 
     private static boolean isReleaseGA(Release r) {

--- a/src/test/java/org/jboss/jbossset/bugclerk/utils/FixVersionHelperTest.java
+++ b/src/test/java/org/jboss/jbossset/bugclerk/utils/FixVersionHelperTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.Assert.*;
 
@@ -82,10 +83,10 @@ public class FixVersionHelperTest {
     private void testWithWrongVersions() {
         List<Issue> issuesWithDifferentVersion = createIssuesAndFilterIssueWithWrongVersion(correctVersion, wrongVersion);
         assertEquals("Check if there is 1 issue with wrong version.", 1, issuesWithDifferentVersion.size());
-
-        JiraIssue bugIssue = createIssueWithRelease(new Release(wrongVersion));
-        assertEquals("Check if the bug issue with wrong 7.0.8.GA version is found.", bugIssue,
-                (issuesWithDifferentVersion.size() > 0) ? issuesWithDifferentVersion.get(0) : null);
+        Optional<String> versionOfFoundIssue = (issuesWithDifferentVersion.size() > 0)
+                ? issuesWithDifferentVersion.get(0).getReleases().get(0).getVersion() : Optional.of("");
+        assertEquals("Check if the bug issue with wrong 7.0.8.GA version is found.", versionOfFoundIssue,
+                Optional.of(wrongVersion));
     }
 
     private List<Issue> createIssuesAndFilterIssueWithWrongVersion(String version, String version1) {


### PR DESCRIPTION
Use optional instead of returning null and use collect in streams.

Bugclerk issue : https://github.com/jboss-set/bug-clerk/issues/64