### PR TITLE
Use repositories info from streams during PR links checks.

### DIFF
--- a/src/main/java/org/jboss/jbossset/bugclerk/aphrodite/AphroditeClient.java
+++ b/src/main/java/org/jboss/jbossset/bugclerk/aphrodite/AphroditeClient.java
@@ -31,6 +31,8 @@ public class AphroditeClient {
 
     private static final int DEFAULT_ISSUE_LIMIT = 400;
 
+    private List<Stream> allStreams;
+
     public AphroditeClient() {
         try {
             aphrodite = Aphrodite.instance();
@@ -80,7 +82,11 @@ public class AphroditeClient {
     }
 
     public List<Stream> getAllStreams() {
-        return execute(new AllStreamsTask(aphrodite));
+        //Lazy loading of the streams
+        if (allStreams == null) {
+            allStreams = execute(new AllStreamsTask(aphrodite));
+        }
+        return allStreams;
     }
 
     public PullRequest getPullRequest(String pullRequestUrl) {

--- a/src/main/resources/org/jboss/jbossset/bugclerk/PRLinksNotValid.drl
+++ b/src/main/resources/org/jboss/jbossset/bugclerk/PRLinksNotValid.drl
@@ -25,17 +25,37 @@ package org.jboss.jbossset.bugclerk;
 import org.jboss.set.aphrodite.issue.trackers.jira.JiraIssue;
 import org.jboss.jbossset.bugclerk.Violation;
 import org.jboss.jbossset.bugclerk.utils.GitHelper;
+import org.jboss.set.aphrodite.domain.Stream;
+
 import java.net.URL;
 import java.util.List;
+
+global org.jboss.jbossset.bugclerk.aphrodite.AphroditeClient aphrodite;
 
 rule "PRLinksNotValid"
   salience 0
   dialect "mvel"
   when
     $candidate : Candidate( $jiraIssue: bug#JiraIssue, bug#JiraIssue.getPullRequests() != null, bug#JiraIssue.getPullRequests().isEmpty() != true, filtered == false )
-    $list : List() from collect (String() from GitHelper.getIncorrectPRs($jiraIssue));
+    $stream : Stream() from GitHelper.getStreamForIssue($jiraIssue, aphrodite);
+    $list : List() from collect (String() from GitHelper.getIncorrectPRs($jiraIssue, $stream));
     eval( ! $list.isEmpty() )
   then
     $candidate.addViolation(new Violation("PRLinksNotValid",
-    "Issue has " + $list.size() + " invalid pull requests: " + String.join(", ", $list), Severity.MINOR));
+        "Following PRs "+String.join(", ", $list)+" don't belong to the expected list of repositoires in '"+$stream.getName()+
+        "' stream specified in https://raw.githubusercontent.com/jboss-set/jboss-streams/master/streams.json",
+    Severity.MINOR));
+end
+
+rule "PRLinksNoStreamsFound"
+  salience 0
+  dialect "mvel"
+  when
+    $candidate : Candidate( $jiraIssue: bug#JiraIssue, bug#JiraIssue.getPullRequests() != null, bug#JiraIssue.getPullRequests().isEmpty() != true, filtered == false )
+    $stream : Stream() from GitHelper.getStreamForIssue($jiraIssue, aphrodite);
+    eval($stream.getName().equals("none"))
+  then
+    $candidate.addViolation(new Violation("PRLinksNoStreamsFound",
+         "No valid streams was found for this issue in the https://raw.githubusercontent.com/jboss-set/jboss-streams/master/streams.json.",
+    Severity.MINOR));
 end


### PR DESCRIPTION
Use repositories info from streams during PR links checks in order to minimize false positive violations.

Bugclerk issue: https://github.com/jboss-set/bug-clerk/issues/57
