### PR TITLE
Drools upgrade and expose processEntriesAndReportViolations public

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -53,6 +53,12 @@
       <groupId>org.drools</groupId>
       <artifactId>drools-core</artifactId>
       <version>${version.org.drools}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.mvel</groupId>
+          <artifactId>mvel2</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>

--- a/core/src/main/java/org/jboss/jbossset/bugclerk/BugClerk.java
+++ b/core/src/main/java/org/jboss/jbossset/bugclerk/BugClerk.java
@@ -50,7 +50,7 @@ public class BugClerk {
         this.configuration = configuration;
     }
 
-    protected Collection<Candidate> processEntriesAndReportViolations(List<Candidate> candidates) {
+    public Collection<Candidate> processEntriesAndReportViolations(List<Candidate> candidates) {
         return processEntriesAndReportViolations(candidates, configuration.getChecknames());
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,10 +30,8 @@
     <mockito.version>1.9.5</mockito.version>
     <org.wildfly.checkstyle-config.version>1.0.4.Final</org.wildfly.checkstyle-config.version>
 
-    <version.drools>7.4.1.Final</version.drools>
-    <version.org.drools>${version.drools}</version.org.drools>
+    <version.org.drools>7.15.0.Final</version.org.drools>
     <version.org.jboss.set.aphrodite>0.7.4.Final</version.org.jboss.set.aphrodite>
-    <version.org.kie>${version.drools}</version.org.kie>
     <version.enforcer.plugin>3.0.0-M1</version.enforcer.plugin>
   </properties>
 


### PR DESCRIPTION
See report in SET-104
This includes
1. Upgrade drools to 7.15.0 to resolve issue DROOLS-3181
2.  expose processEntriesAndReportViolations and allow to only process issue entries like old RuleEngine allowed

