### PR TITLE
Log a warning message instead of throw exception.

### DIFF
--- a/core/src/main/java/org/jboss/jbossset/bugclerk/aphrodite/callables/GetPullRequest.java
+++ b/core/src/main/java/org/jboss/jbossset/bugclerk/aphrodite/callables/GetPullRequest.java
@@ -1,7 +1,9 @@
 package org.jboss.jbossset.bugclerk.aphrodite.callables;
 
 import java.net.URL;
+import java.util.logging.Level;
 
+import org.jboss.jbossset.bugclerk.utils.LoggingUtils;
 import org.jboss.set.aphrodite.Aphrodite;
 import org.jboss.set.aphrodite.domain.PullRequest;
 import org.jboss.set.aphrodite.spi.NotFoundException;
@@ -20,8 +22,8 @@ public class GetPullRequest extends AphroditeCallable<PullRequest> {
         try {
             return aphrodite.getPullRequest(pullRequest);
         } catch (NotFoundException e) {
-            throw new IllegalArgumentException("No such Pull Requests:" + pullRequest, e);
+            LoggingUtils.getLogger().log(Level.WARNING, "Unable to get pull request from url : " + pullRequest);
+            return null;
         }
     }
-
 }

--- a/core/src/main/java/org/jboss/jbossset/bugclerk/utils/PullRequestUtils.java
+++ b/core/src/main/java/org/jboss/jbossset/bugclerk/utils/PullRequestUtils.java
@@ -15,7 +15,10 @@ public class PullRequestUtils {
     public static Collection<PullRequest> fetchPullRequests(final AphroditeClient client, List<URL> urls) {
         final List<PullRequest> pullRequests = new ArrayList<>();
         for (URL url : urls) {
-            pullRequests.add(client.getPullRequestAsString(url.toString()));
+            PullRequest pr = client.getPullRequestAsString(url.toString());
+            if (pr != null) {
+                pullRequests.add(pr);
+            }
         }
         return pullRequests;
     }


### PR DESCRIPTION
This helps to reduce massive log messages in server as exception stacktrace is logged for each bug clerk rule.

Log a warning as:

`16:26:08,829 WARNING [org.jboss.jbossset.bugclerk.BugClerk] (Thread-507) Unable to get pull request from url : https://github.com/undertow-io/undertow/commit/440288804bb4a57c23d8994a3429d826db63160a`

Instead log long exception stacktrace:

```
16:04:44,866 WARNING [org.jboss.jbossset.bugclerk.BugClerk] (pool-6-thread-7) Callable failed.: java.util.concurrent.ExecutionException: java.lang.IllegalArgumentException: No such Pull Requests:https://github.com/hibernate/hibernate-orm/commit/bc706b7aa41a000926d14c46e4e56cf9f010627b
	at java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.util.concurrent.FutureTask.get(FutureTask.java:206)
	at org.jboss.jbossset.bugclerk.utils.ThreadUtil.execute(ThreadUtil.java:26)
	at org.jboss.jbossset.bugclerk.aphrodite.AphroditeClient.getPullRequest(AphroditeClient.java:104)
	at org.jboss.jbossset.bugclerk.aphrodite.AphroditeClient.getPullRequestAsString(AphroditeClient.java:100)
	at org.jboss.jbossset.bugclerk.checks.RulesHelper.populateReposAndCodeBases(RulesHelper.java:156)
	at org.jboss.jbossset.bugclerk.checks.RulesHelper.arePullRequestsAgainstSameTarget(RulesHelper.java:149)
	at sun.reflect.GeneratedMethodAccessor103.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.mvel2.optimizers.impl.refl.nodes.MethodAccessor.getValue(MethodAccessor.java:40)
	at org.mvel2.optimizers.impl.refl.nodes.VariableAccessor.getValue(VariableAccessor.java:37)
	at org.mvel2.ast.ASTNode.getReducedValueAccelerated(ASTNode.java:108)
	at org.mvel2.ast.BinaryOperation.getReducedValueAccelerated(BinaryOperation.java:125)
	at org.mvel2.MVELRuntime.execute(MVELRuntime.java:85)
	at org.mvel2.compiler.CompiledExpression.getDirectValue(CompiledExpression.java:123)
	at org.mvel2.compiler.CompiledExpression.getValue(CompiledExpression.java:119)
	at org.mvel2.MVEL.executeExpression(MVEL.java:929)
	at org.drools.core.base.mvel.MVELEvalExpression.evaluate(MVELEvalExpression.java:102)
	at org.drools.core.rule.EvalCondition.isAllowed(EvalCondition.java:129)
	at org.drools.core.phreak.PhreakEvalNode.doLeftInserts(PhreakEvalNode.java:72)
	at org.drools.core.phreak.PhreakEvalNode.doNode(PhreakEvalNode.java:56)
	at org.drools.core.phreak.RuleNetworkEvaluator.evalNode(RuleNetworkEvaluator.java:387)
	at org.drools.core.phreak.RuleNetworkEvaluator.innerEval(RuleNetworkEvaluator.java:339)
	at org.drools.core.phreak.RuleNetworkEvaluator.outerEval(RuleNetworkEvaluator.java:175)
	at org.drools.core.phreak.RuleNetworkEvaluator.evaluateNetwork(RuleNetworkEvaluator.java:133)
	at org.drools.core.phreak.RuleExecutor.reEvaluateNetwork(RuleExecutor.java:212)
	at org.drools.core.phreak.RuleExecutor.evaluateNetworkAndFire(RuleExecutor.java:87)
	at org.drools.core.concurrent.AbstractRuleEvaluator.internalEvaluateAndFire(AbstractRuleEvaluator.java:34)
	at org.drools.core.concurrent.SequentialRuleEvaluator.evaluateAndFire(SequentialRuleEvaluator.java:43)
	at org.drools.core.common.DefaultAgenda.fireLoop(DefaultAgenda.java:1066)
	at org.drools.core.common.DefaultAgenda.internalFireAllRules(DefaultAgenda.java:1013)
	at org.drools.core.common.DefaultAgenda.fireAllRules(DefaultAgenda.java:1005)
	at org.drools.core.impl.StatefulKnowledgeSessionImpl.internalFireAllRules(StatefulKnowledgeSessionImpl.java:1345)
	at org.drools.core.impl.StatefulKnowledgeSessionImpl.fireAllRules(StatefulKnowledgeSessionImpl.java:1336)
	at org.drools.core.impl.StatefulKnowledgeSessionImpl.fireAllRules(StatefulKnowledgeSessionImpl.java:1328)
	at org.jboss.jbossset.bugclerk.RulesEngine.runChecksOnBugs(RulesEngine.java:88)
	at org.jboss.jbossset.bugclerk.BugClerk.processEntriesAndReportViolations(BugClerk.java:59)
	at org.jboss.jbossset.bugclerk.BugClerk.processEntriesAndReportViolations(BugClerk.java:54)
	at org.jboss.set.assistant.ViolationHomeService.findViolations(ViolationHomeService.java:58)
	at org.jboss.set.assistant.evaluator.impl.payload.PayloadIssueEvaluator.eval(PayloadIssueEvaluator.java:63)
	at org.jboss.set.overview.processor.PayloadOverviewProcessor$PayloadProcessingTask.call(PayloadOverviewProcessor.java:219)
	at org.jboss.set.overview.processor.PayloadOverviewProcessor$PayloadProcessingTask.call(PayloadOverviewProcessor.java:183)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.IllegalArgumentException: No such Pull Requests:https://github.com/hibernate/hibernate-orm/commit/bc706b7aa41a000926d14c46e4e56cf9f010627b
	at org.jboss.jbossset.bugclerk.aphrodite.callables.GetPullRequest.call(GetPullRequest.java:27)
	at org.jboss.jbossset.bugclerk.aphrodite.callables.GetPullRequest.call(GetPullRequest.java:11)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	... 1 more
Caused by: org.jboss.set.aphrodite.spi.NotFoundException: java.lang.NumberFormatException: For input string: "bc706b7aa41a000926d14c46e4e56cf9f010627b"
	at org.jboss.set.aphrodite.repository.services.github.GitHubRepositoryService.getPullRequest(GitHubRepositoryService.java:96)
	at org.jboss.set.aphrodite.Aphrodite.getPullRequest(Aphrodite.java:640)
	at org.jboss.jbossset.bugclerk.aphrodite.callables.GetPullRequest.call(GetPullRequest.java:23)
	... 3 more
Caused by: java.lang.NumberFormatException: For input string: "bc706b7aa41a000926d14c46e4e56cf9f010627b"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Integer.parseInt(Integer.java:580)
	at java.lang.Integer.parseInt(Integer.java:615)
	at org.jboss.set.aphrodite.repository.services.github.GitHubRepositoryService.getPullRequest(GitHubRepositoryService.java:89)
	... 5 more
```