### PR TITLE
SET-430 bump aphrodite to 0.7.15.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <org.wildfly.checkstyle-config.version>1.0.4.Final</org.wildfly.checkstyle-config.version>
 
     <version.org.drools>7.15.0.Final</version.org.drools>
-    <version.org.jboss.set.aphrodite>0.7.14.Final</version.org.jboss.set.aphrodite>
+    <version.org.jboss.set.aphrodite>0.7.15.Final</version.org.jboss.set.aphrodite>
     <version.enforcer.plugin>3.0.0-M1</version.enforcer.plugin>
   </properties>
 


### PR DESCRIPTION
Jira will decommission Basic Authentication Dec 11, 2021. We need

1. Upgrade Aphrodite 0.7.15.Final (implemented Bearer Token Auth) in bug-clerk and release a new 1.0.7.Final.
2. Bump up Bug clerk version 1.0.7.Final in `bug-clerk-report-job`, both EAP_720 and EAP_730 branches. 
3. Update Aphrodite configuration in `zeus-var` in order to use the new token for Jira. 